### PR TITLE
docs: add MIT LICENSE, FUNDING and community sections

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# GitHub 原生赞助列表不含爱发电，走 custom 自定义链接
+custom: ['https://afdian.com/a/penglonghuang']

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PenglongHuang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -266,6 +266,15 @@ chinese-novelist/
 
 ---
 
+## 💬 交流
+
+- 💬 [GitHub Discussions](https://github.com/PenglongHuang/chinese-novelist-skill/discussions) — 使用心得、作品分享、功能想法
+- 🐛 [Issues](https://github.com/PenglongHuang/chinese-novelist-skill/issues) — 问题反馈与 bug 报告
+
+## 💖 赞助
+
+如果这个项目帮你写出了第一部小说，可以考虑[在爱发电赞助我](https://afdian.com/a/penglonghuang)，你的支持直接决定项目的更新速度 ⚡
+
 ## ⚖️ 许可
 
-MIT
+[MIT](LICENSE)


### PR DESCRIPTION
## 变更内容

- 新增 **MIT LICENSE**：修复 README 徽章死链，GitHub License 检测恢复为 MIT（热度评估报告风险 ②）
- 新增 **.github/FUNDING.yml**：爱发电 custom 链接，合并后仓库主页出现 Sponsor 按钮
- README 尾部：新增 💬 交流（Discussions / Issues）与 💖 赞助（爱发电）两节；⚖️ 许可 改为 LICENSE 链接

🤖 Generated with [Claude Code](https://claude.com/claude-code)